### PR TITLE
fix: Added KeyError exception catching

### DIFF
--- a/tgbot/services/youtube.py
+++ b/tgbot/services/youtube.py
@@ -1,12 +1,38 @@
 """Functions for downloading videos from YouTube"""
 
-from asyncio import get_running_loop
+from asyncio import get_running_loop, sleep
+from typing import Any, Callable
 
 from pytube import Stream, YouTube
 from pytube.exceptions import PytubeError
 
 from tgbot.config import TEMP_DIR
 from tgbot.misc.logger import logger
+
+
+def retry(max_retries: int) -> Callable:
+    """A decorator that calls a function and, if an exception occurs, calls it again up to max_retries times"""
+
+    def retry_decorator(func: Callable) -> Callable:
+        """Internal decorator function that wraps the decorated asynchronous function"""
+
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """
+            A wrapped asynchronous function that catches a KeyError exception and, if it occurs, calls
+            the decorated function, up to max_retries times
+            """
+            retries: int = 0
+            while retries < max_retries:
+                try:
+                    return await func(*args, **kwargs)
+                except KeyError:
+                    retries += 1
+                    await sleep(1)
+            return None
+
+        return wrapper
+
+    return retry_decorator
 
 
 def _remove_unwanted_chars(string: str) -> str:
@@ -34,6 +60,7 @@ def download_video(url: str) -> str | None:
     return None
 
 
+@retry(max_retries=10)
 async def get_path_to_video_file(url: str | None) -> str | None:
     """Returns the path to the downloaded audio file"""
     path_to_mp4_file: str | None = await get_running_loop().run_in_executor(None, download_video, url)


### PR DESCRIPTION
When trying to retrieve streaming data in a video, a KeyError : 'streamingData' exception will often occur, for example, when trying to download a video with an age restriction.

However, when downloading
unrestricted videos, this error also often occurs.

Added a decorator
that restarts the function that downloads the video up to 10 times, which is enough to download videos for which there are no restrictions